### PR TITLE
Refrain from logging user data. (#227)

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -694,14 +694,14 @@ streamWrite(LogicalStreamContext *context)
 
 	if (metadata->xid > 0)
 	{
-		log_debug("Received action %c for XID %u at LSN %X/%X",
+		log_trace("Received action %c for XID %u at LSN %X/%X",
 				  metadata->action,
 				  metadata->xid,
 				  LSN_FORMAT_ARGS(metadata->lsn));
 	}
 	else
 	{
-		log_debug("Received action %c at LSN %X/%X",
+		log_trace("Received action %c at LSN %X/%X",
 				  metadata->action,
 				  LSN_FORMAT_ARGS(metadata->lsn));
 	}
@@ -1090,7 +1090,7 @@ streamKeepalive(LogicalStreamContext *context)
 
 		fformat(privateContext->jsonFile, "%s", buffer);
 
-		log_debug("Inserted action KEEPALIVE for lsn %X/%X @%s",
+		log_trace("Inserted action KEEPALIVE for lsn %X/%X @%s",
 				  LSN_FORMAT_ARGS(context->cur_record_lsn),
 				  sendTimeStr);
 
@@ -1604,7 +1604,7 @@ updateStreamCounters(StreamContext *context, LogicalMessageMetadata *metadata)
 
 		default:
 		{
-			log_debug("Skipping counters for message action \"%c\"",
+			log_trace("Skipping counters for message action \"%c\"",
 					  metadata->action);
 			break;
 		}

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -180,6 +180,8 @@ typedef struct PGSQL
 	int notificationGroupId;
 	int64_t notificationNodeId;
 	bool notificationReceived;
+
+	bool logSQL;
 } PGSQL;
 
 


### PR DESCRIPTION
In the apply process logging the SQL statements opens the door to logging user data. For privacy concerns, reduce the apply module logging.

Also reduce the amount of logs sent by the receive and apply processes in general, as this can lead to a very large volume of data and we do not anciticape needing that level of details to be able to debug operations.